### PR TITLE
Ansible 2.8, Ubuntu Bionic and Travis pipeline improvements

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,19 +1,49 @@
+# EditorConfig: https://editorconfig.org
 root = true
 
+# Unix-style newlines with a newline ending every file
 [*]
 end_of_line = lf
 insert_final_newline = true
 trim_trailing_whitespace = true
 charset = utf-8
 
-[{update-*,tests/run-tests-*}]
+# Shell scripts without extension
+[{update-*,tests/run-*,tests/update}]
 indent_style = space
 indent_size = 4
 
+# Shell scripts
+[{*.sh}]
+indent_style = space
+indent_size = 4
+
+# Markdown files
 [*.md]
 indent_style = space
 indent_size = 2
 
+# YAML files
 [{*.yml,*.yaml}]
 indent_style = space
+indent_size = 2
+
+# YAML files without extension
+[{.ansible-lint,.yamllint}]
+indent_style = space
+indent_size = 2
+
+# JSON files
+[{*.json}]
+indent_style = space
+indent_size = 2
+
+# Dockerfile
+[{Dockerfile,Dockerfile.template}]
+indent_style = space
+indent_size = 2
+
+# Makefile
+[Makefile]
+indent_style = tab
 indent_size = 2

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+# Ignore Ansible files generated during development and testing
 *.retry
 ansible.cfg
 

--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,9 +1,16 @@
 {
     "default": true,
-    "MD003": {
+    "heading-style": {
         "style": "atx"
     },
-    "MD024": {
+    "line-length": {
+        "code_blocks": false,
+        "tables": false
+    },
+    "no-duplicate-heading": {
         "siblings_only": true
+    },
+    "code-block-style": {
+        "style": "fenced"
     }
 }

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,38 +1,40 @@
 # -*- mode: yaml -*-
 # vim:ts=2:sw=2:ai:si:syntax=yaml
-#
+################################
 # pre-commit hooks configuration
+################################
 ---
 
 repos:
-- repo: https://github.com/pre-commit/pre-commit-hooks.git
-  rev: v2.1.0
-  hooks:
-    - id: trailing-whitespace
-    - id: check-yaml
+  - repo: https://github.com/pre-commit/pre-commit-hooks.git
+    rev: v2.1.0
+    hooks:
+      - id: check-executables-have-shebangs
+      - id: trailing-whitespace
+      - id: check-yaml
 
-- repo: https://github.com/adrienverge/yamllint.git
-  rev: v1.15.0
-  hooks:
-    - id: yamllint
+  - repo: https://github.com/adrienverge/yamllint.git
+    rev: v1.15.0
+    hooks:
+      - id: yamllint
 
-- repo: https://github.com/ansible/ansible-lint.git
-  rev: v4.1.0
-  hooks:
-    - id: ansible-lint
-      files: \.(yaml|yml)$
+  - repo: https://github.com/ansible/ansible-lint.git
+    rev: v4.1.0
+    hooks:
+      - id: ansible-lint
+        files: \.(yaml|yml)$
 
-- repo: https://github.com/bemeurer/beautysh.git
-  rev: '4.1'
-  hooks:
-    - id: beautysh
+  - repo: https://github.com/bemeurer/beautysh.git
+    rev: '4.1'
+    hooks:
+      - id: beautysh
 
-- repo: https://github.com/openstack-dev/bashate.git
-  rev: '0.6.0'
-  hooks:
-    - id: bashate
+  - repo: https://github.com/openstack-dev/bashate.git
+    rev: '0.6.0'
+    hooks:
+      - id: bashate
 
-- repo: https://github.com/igorshubovych/markdownlint-cli.git
-  rev: 'v0.15.0'
-  hooks:
-    - id: markdownlint
+  - repo: https://github.com/igorshubovych/markdownlint-cli.git
+    rev: 'v0.15.0'
+    hooks:
+      - id: markdownlint

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 # -*- mode: yaml -*-
 # vim:ts=2:sw=2:ai:si:syntax=yaml
-#
-# Travis CI configuration
+#########################
+# Travis CI configuration
+#########################
 ---
 
 language: generic

--- a/.travis.yml
+++ b/.travis.yml
@@ -73,14 +73,31 @@ script:
 
   # Test role run
   - >
-    ansible-playbook tests/test.yml -i tests/inventory --connection=local
+    if [[ "$FROM_PACKAGE_MANAGER" == "yes" ]]; then
+      ansible-playbook tests/test.yml -i tests/inventory --connection=local \
+        -e "{'pyenv_install_from_package_manager':'True'}" \
+        || travis_terminate 1
+    else
+      ansible-playbook tests/test.yml -i tests/inventory --connection=local \
+        -e "{'pyenv_install_from_package_manager':'False'}" \
+        || travis_terminate 1
+    fi
 
   # Test idempotence
   - >
-    ansible-playbook tests/test.yml -i tests/inventory --connection=local
-    | grep -q 'changed=0.*failed=0'
-    && (echo 'Idempotence test: pass' && exit 0)
-    || (echo 'Idempotence test: fail' && exit 1)
+    if [[ "$FROM_PACKAGE_MANAGER" == "yes" ]]; then
+      ansible-playbook tests/test.yml -i tests/inventory --connection=local \
+      -e "{'pyenv_install_from_package_manager':'True'}" \
+        | grep -q 'changed=0.*failed=0' \
+        && (echo 'Idempotence test: pass' && exit 0) \
+        || (echo 'Idempotence test: fail' && exit 1)
+    else
+      ansible-playbook tests/test.yml -i tests/inventory --connection=local \
+      -e "{'pyenv_install_from_package_manager':'False'}" \
+        | grep -q 'changed=0.*failed=0' \
+        && (echo 'Idempotence test: pass' && exit 0) \
+        || (echo 'Idempotence test: fail' && exit 1)
+    fi
 
   # Test global python version is defined
   - . $HOME/.pyenv/.pyenvrc && pyenv version
@@ -93,6 +110,10 @@ stages:
   - test
 
 jobs:
+  allow_failures:
+    - osx_image: xcode10.2
+      env: FROM_PACKAGE_MANAGER='yes'
+
   include:
 
     # Run validation stage in Linux with latest Ansible only
@@ -123,14 +144,26 @@ jobs:
       env: ANSIBLE_VERSION='<2.9.0'
 
     - stage: test
-      name: "macOS 10.13 (High Sierra) with Xcode 10.1"
+      name: "macOS 10.13 (High Sierra) with Xcode 10.1 with Homebrew"
       os: osx
       osx_image: xcode10.1
+      env: FROM_PACKAGE_MANAGER='yes'
+    - stage: test
+      name: "macOS 10.13 (High Sierra) with Xcode 10.1 from Git"
+      os: osx
+      osx_image: xcode10.1
+      env: FROM_PACKAGE_MANAGER='no'
 
     - stage: test
-      name: "macOS 10.14 (Mojave) with Xcode 10.2.1"
+      name: "macOS 10.14 (Mojave) with Xcode 10.2.1 with Homebrew"
       os: osx
       osx_image: xcode10.2
+      env: FROM_PACKAGE_MANAGER='yes'
+    - stage: test
+      name: "macOS 10.14 (Mojave) with Xcode 10.2.1 from Git"
+      os: osx
+      osx_image: xcode10.2
+      env: FROM_PACKAGE_MANAGER='no'
 
 notifications:
   webhooks:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,82 +5,47 @@
 #########################
 ---
 
+# Run tests against pull requests and main branches only
+if: |
+  type = pull_request OR \
+  branch IN (master, develop)
+
 language: generic
-python: "2.7"
+sudo: required
 
-matrix:
-  include:
-    - name: "Ubuntu 16.04 (Xenial) with Ansible 2.6"
-      os: linux
-      dist: xenial
-      sudo: required
-      env: ANSIBLE_VERSION='<2.7.0'
-    - name: "Ubuntu 16.04 (Xenial) with Ansible 2.7"
-      os: linux
-      dist: xenial
-      sudo: required
-      env: ANSIBLE_VERSION='<2.8.0'
-    - name: "Ubuntu 16.04 (Xenial) with Ansible 2.8"
-      os: linux
-      dist: xenial
-      sudo: required
-      env: ANSIBLE_VERSION='<2.9.0'
-    - name: "macOS 10.13 (High Sierra) with Xcode 10.1"
-      os: osx
-      osx_image: xcode10.1
-    - name: "macOS 10.14 (Mojave) with Xcode 10.2.1"
-      os: osx
-      osx_image: xcode10.2
-
+# Install Ansible and Python development packages
 addons:
   apt:
     packages:
       - python-pip
       - python-dev
+    update: true
   homebrew:
     packages:
       - ansible
       - pre-commit
-
-branches:
-  only:
-    - master
-    - develop
-    - /^feature\/.*$/
-    - /^bugfix\/.*$/
-    - /^v\d+\.\d+(\.\d+)?(-\S*)?$/
+    update: true
 
 cache:
   directories:
     - $HOME/.cache/pre-commit/
 
-before_cache:
-  - rm -f $HOME/.cache/pre-commit/pre-commit.log
-
 before_install:
-  # Import new GPG key for RVM when necessary
-  - >
-    if [[ "$RVM_GPG_IMPORT" == "yes" ]]; then
-      command curl -sSL https://rvm.io/mpapis.asc | gpg --import -
-    fi
-
-  # Update Homebrew to fix HOMEBREW_LOGS error
-  - if [[ "$BREW_UPGRADE" == "yes" ]]; then brew update; fi
-
-  # Upgrade Ansible with installed Homebrew
-  - if [[ "$BREW_UPGRADE" == "yes" ]]; then brew upgrade ansible; fi
-
-  # Upgrade pre-commit installed with Homebrew
-  - if [[ "$BREW_UPGRADE" == "yes" ]]; then brew upgrade pre-commit; fi
-
   # Existing pyenv installation on Linux conflicts with ours
-  - if [[ "$TRAVIS_OS_NAME" != "osx" ]]; then rm -rf /opt/pyenv; fi
+  - >
+    if [[ "$TRAVIS_OS_NAME" != "osx" ]]; then
+      rm -rf /opt/pyenv
+    fi
 
 install:
   # Install Ansible with pip on Ubuntu
   - >
     if [[ "$TRAVIS_OS_NAME" != "osx" ]]; then
-      pip install --user ansible${ANSIBLE_VERSION}
+      if [[ -z "$ANSIBLE_VERSION" ]]; then
+        pip install --user ansible
+      else
+        pip install --user ansible${ANSIBLE_VERSION}
+      fi
     fi
 
   # Install pre-commit with pip on Ubuntu
@@ -97,12 +62,12 @@ install:
 
 before_script:
   # https://github.com/travis-ci/travis-ci/issues/6307
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then rvm get head || true; fi
+  - >
+    if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
+      rvm get head || true
+    fi
 
 script:
-  # Run pre-commit hooks
-  - pre-commit run -a
-
   # Basic role syntax check
   - ansible-playbook tests/test.yml -i tests/inventory --syntax-check
 
@@ -119,6 +84,53 @@ script:
 
   # Test global python version is defined
   - . $HOME/.pyenv/.pyenvrc && pyenv version
+
+before_cache:
+  - rm -f $HOME/.cache/pre-commit/pre-commit.log
+
+stages:
+  - validate
+  - test
+
+jobs:
+  include:
+
+    # Run validation stage in Linux with latest Ansible only
+    - stage: validate
+      name: Validate with pre-commit
+      os: linux
+      dist: xenial
+      language: minimal
+      script:
+        - pre-commit run -a
+
+    # Run tests
+    - stage: test
+      name: "Ubuntu 16.04 (Xenial) with Ansible 2.6"
+      os: linux
+      dist: xenial
+      env: ANSIBLE_VERSION='<2.7.0'
+    - stage: test
+      name: "Ubuntu 16.04 (Xenial) with Ansible 2.7"
+      os: linux
+      dist: xenial
+      env: ANSIBLE_VERSION='<2.8.0'
+
+    - stage: test
+      name: "Ubuntu 18.04 (Bionic) with Ansible 2.8"
+      os: linux
+      dist: bionic
+      env: ANSIBLE_VERSION='<2.9.0'
+
+    - stage: test
+      name: "macOS 10.13 (High Sierra) with Xcode 10.1"
+      os: osx
+      osx_image: xcode10.1
+
+    - stage: test
+      name: "macOS 10.14 (Mojave) with Xcode 10.2.1"
+      os: osx
+      osx_image: xcode10.2
 
 notifications:
   webhooks:

--- a/.yamllint
+++ b/.yamllint
@@ -7,7 +7,7 @@
 # Overriding rules in files:
 # http://yamllint.readthedocs.io/en/latest/disable_with_comments.html
 ---
-extends: relaxed
+extends: default
 
 # Rules documentation: http://yamllint.readthedocs.io/en/latest/rules.html
 rules:
@@ -15,20 +15,15 @@ rules:
   document-start:
     present: true
 
-  braces:
-    # Allowing one space inside braces to improve code readability
-    max-spaces-inside: 1
-
-  brackets:
-    # Allowing one space inside braces to improve code readability
-    max-spaces-inside: 1
-
   indentation:
     # Requiring 2 space indentation
     spaces: 2
     # Requiring consistent indentation within a file, either indented or not
-    indent-sequences: consistent
+    indent-sequences: true
+    # Lint indentation in multi-line strings
+    check-multi-line-strings: false
 
   line-length:
     max: 80
     level: warning
+    allow-non-breakable-inline-mappings: true

--- a/README.md
+++ b/README.md
@@ -29,6 +29,17 @@ This role installs macOS SDK headers from
 `/Library/Developer/CommandLineTools/Packages/macOS_SDK_headers_for_macOS_10.14.pkg`
 if they're not found in `/usr/include`.
 
+## Configuration
+
+To install pyenv and plugins from the package manager where available, enable
+this in Ansible configuration:
+
+```yaml
+pyenv_install_from_package_manager: true
+```
+
+This is supported on macOS with Homebrew only.
+
 ## Installed Python versions
 
 This role installs [Python] versions defined in `pyenv_python_versions` variable.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -6,7 +6,7 @@ pyenv_home: "{{ ansible_env.HOME }}"
 pyenv_root: "{{ ansible_env.HOME }}/.pyenv"
 
 # Configure shell
-pyenv_init_shell: yes
+pyenv_init_shell: true
 
 # Versions to install
 pyenv_version: "v1.2.11"
@@ -26,5 +26,5 @@ pyenv_python_versions:
 pyenv_global: "{{ pyenv_python2_version }} {{ pyenv_python3_version }} system"
 
 # Optionally, install virtualenvwrapper plugin for pyenv
-pyenv_virtualenvwrapper: no
+pyenv_virtualenvwrapper: false
 pyenv_virtualenvwrapper_home: "{{ ansible_env.HOME }}/.virtualenvs"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -28,3 +28,6 @@ pyenv_global: "{{ pyenv_python2_version }} {{ pyenv_python3_version }} system"
 # Optionally, install virtualenvwrapper plugin for pyenv
 pyenv_virtualenvwrapper: false
 pyenv_virtualenvwrapper_home: "{{ ansible_env.HOME }}/.virtualenvs"
+
+# Install using package manager where available
+pyenv_install_from_package_manager: false

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,3 +1,5 @@
+# -*- mode: yaml -*-
+# vim:ts=2:sw=2:ai:si:syntax=yaml
 ---
 galaxy_info:
   role_name: pyenv
@@ -7,18 +9,18 @@ galaxy_info:
   min_ansible_version: 2.6
   github_branch: master
   platforms:
-   - name: Debian
-     versions:
-     - buster
-     - stretch
-   - name: Ubuntu
-     versions:
-     - xenial
-     - bionic
-   - name: MacOSX
-     versions:
-     - '10.13'
-     - '10.14'
+    - name: Debian
+      versions:
+        - buster
+        - stretch
+    - name: Ubuntu
+      versions:
+        - xenial
+        - bionic
+    - name: MacOSX
+      versions:
+        - '10.13'
+        - '10.14'
   galaxy_tags:
     - osx
     - macos

--- a/tasks/Darwin.yml
+++ b/tasks/Darwin.yml
@@ -26,4 +26,4 @@
 - name: Install pyenv-virtualenvwrapper with Homebrew
   package:
     name: pyenv-virtualenvwrapper
-  when: pyenv_virtualenvwrapper
+  when: pyenv_virtualenvwrapper|bool

--- a/tasks/Darwin.yml
+++ b/tasks/Darwin.yml
@@ -13,18 +13,13 @@
     creates: /usr/include
 
 - name: Install pyenv build requirements with Homebrew
-  package:
+  homebrew:
     name: "{{ pyenv_build_requirements }}"
 
-- name: Install pyenv with Homebrew
-  package:
-    name: pyenv
+- name: Install with Homebrew
+  include_tasks: install_with_homebrew.yml
+  when: pyenv_install_from_package_manager|bool
 
-- name: Install pyenv-virtualenv with Homebrew
-  package:
-    name: pyenv-virtualenv
-
-- name: Install pyenv-virtualenvwrapper with Homebrew
-  package:
-    name: pyenv-virtualenvwrapper
-  when: pyenv_virtualenvwrapper|bool
+- name: Install with Git
+  include_tasks: install_with_git.yml
+  when: not pyenv_install_from_package_manager|bool

--- a/tasks/Darwin.yml
+++ b/tasks/Darwin.yml
@@ -2,10 +2,11 @@
 
 - name: Get macOS version
   set_fact:
-    macos_version: "{{ ansible_distribution_version | regex_search('^([0-9]+\\.[0-9]+)') }}"
+    macos_version: "{{ ansible_distribution_version |
+                    regex_search('^([0-9]+\\.[0-9]+)') }}"
 
 - name: Install macOS SDK headers for macOS 10.14 (Mojave)
-  become: yes
+  become: true
   command: "installer -pkg {{ mojave_sdk_headers }} -target /"
   when: macos_version == "10.14"
   args:

--- a/tasks/Linux.yml
+++ b/tasks/Linux.yml
@@ -5,21 +5,5 @@
   package:
     name: "{{ pyenv_build_requirements }}"
 
-- name: Clone pyenv
-  git:
-    repo: https://github.com/pyenv/pyenv.git
-    dest: "{{ pyenv_root }}"
-    version: "{{ pyenv_version }}"
-
-- name: Clone pyenv-virtualenv
-  git:
-    repo: https://github.com/pyenv/pyenv-virtualenv.git
-    dest: "{{ pyenv_root }}/plugins/pyenv-virtualenv"
-    version: "{{ pyenv_virtualenv_version }}"
-
-- name: Clone pyenv-virtualenvwrapper
-  git:
-    repo: https://github.com/pyenv/pyenv-virtualenvwrapper.git
-    dest: "{{ pyenv_root }}/plugins/pyenv-virtualenvwrapper"
-    version: "{{ pyenv_virtualenvwrapper_version }}"
-  when: pyenv_virtualenvwrapper|bool
+- name: Install with Git
+  include_tasks: install_with_git.yml

--- a/tasks/Linux.yml
+++ b/tasks/Linux.yml
@@ -22,4 +22,4 @@
     repo: https://github.com/pyenv/pyenv-virtualenvwrapper.git
     dest: "{{ pyenv_root }}/plugins/pyenv-virtualenvwrapper"
     version: "{{ pyenv_virtualenvwrapper_version }}"
-  when: pyenv_virtualenvwrapper
+  when: pyenv_virtualenvwrapper|bool

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -33,11 +33,12 @@
   args:
     executable: "{{ pyenv_install_shell | default(omit) }}"
   register: pyenv_global_version
-  changed_when: False
+  changed_when: false
 
 - name: Set pyenv_global_active fact
   set_fact:
-    pyenv_global_active: "{{ pyenv_global_version.stdout_lines | join(' ') | trim() }}"
+    pyenv_global_active: "{{ pyenv_global_version.stdout_lines |
+                          join(' ') | trim() }}"
 
 - name: Check if 'system' version is available
   shell: >-
@@ -47,8 +48,8 @@
   args:
     executable: "{{ pyenv_install_shell | default(omit) }}"
   register: pyenv_versions_grep_system
-  changed_when: False
-  failed_when: False
+  changed_when: false
+  failed_when: false
   when: "'system' in pyenv_global"
 
 - name: Remove 'system' from pyenv_global

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -9,7 +9,7 @@
   file:
     path: "{{ pyenv_virtualenvwrapper_home }}"
     state: directory
-  when: pyenv_virtualenvwrapper
+  when: pyenv_virtualenvwrapper|bool
 
 - name: Create .pyenvrc
   template:

--- a/tasks/install_with_git.yml
+++ b/tasks/install_with_git.yml
@@ -1,0 +1,20 @@
+---
+
+- name: Clone pyenv
+  git:
+    repo: https://github.com/pyenv/pyenv.git
+    dest: "{{ pyenv_root }}"
+    version: "{{ pyenv_version }}"
+
+- name: Clone pyenv-virtualenv
+  git:
+    repo: https://github.com/pyenv/pyenv-virtualenv.git
+    dest: "{{ pyenv_root }}/plugins/pyenv-virtualenv"
+    version: "{{ pyenv_virtualenv_version }}"
+
+- name: Clone pyenv-virtualenvwrapper
+  git:
+    repo: https://github.com/pyenv/pyenv-virtualenvwrapper.git
+    dest: "{{ pyenv_root }}/plugins/pyenv-virtualenvwrapper"
+    version: "{{ pyenv_virtualenvwrapper_version }}"
+  when: pyenv_virtualenvwrapper|bool

--- a/tasks/install_with_homebrew.yml
+++ b/tasks/install_with_homebrew.yml
@@ -1,0 +1,14 @@
+---
+
+- name: Install pyenv with Homebrew
+  homebrew:
+    name: pyenv
+
+- name: Install pyenv-virtualenv with Homebrew
+  homebrew:
+    name: pyenv-virtualenv
+
+- name: Install pyenv-virtualenvwrapper with Homebrew
+  homebrew:
+    name: pyenv-virtualenvwrapper
+  when: pyenv_virtualenvwrapper|bool

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -16,7 +16,11 @@
   include_tasks: Darwin.yml
   when: "ansible_os_family == 'Darwin'"
 
-- import_tasks: install.yml
+# Setup directories and configuration
+- import_tasks: setup.yml
+
+# Install Python versions
+- import_tasks: python_versions.yml
 
 - name: Initialise shell
   include_tasks: shell.yml

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -20,4 +20,4 @@
 
 - name: Initialise shell
   include_tasks: shell.yml
-  when: pyenv_init_shell
+  when: pyenv_init_shell|bool

--- a/tasks/python_versions.yml
+++ b/tasks/python_versions.yml
@@ -1,22 +1,5 @@
 ---
 
-- name: Make sure .pyenv directory exists
-  file:
-    path: "{{ pyenv_root }}"
-    state: directory
-
-- name: Make sure WORKON_HOME directory exists
-  file:
-    path: "{{ pyenv_virtualenvwrapper_home }}"
-    state: directory
-  when: pyenv_virtualenvwrapper|bool
-
-- name: Create .pyenvrc
-  template:
-    src: ".pyenvrc.j2"
-    dest: "{{ pyenv_root }}/.pyenvrc"
-    mode: "0644"
-
 - name: Install Python interpreters
   shell: >-
     . {{ pyenv_root }}/.pyenvrc &&

--- a/tasks/setup.yml
+++ b/tasks/setup.yml
@@ -1,0 +1,18 @@
+---
+
+- name: Make sure .pyenv directory exists
+  file:
+    path: "{{ pyenv_root }}"
+    state: directory
+
+- name: Make sure WORKON_HOME directory exists
+  file:
+    path: "{{ pyenv_virtualenvwrapper_home }}"
+    state: directory
+  when: pyenv_virtualenvwrapper|bool
+
+- name: Create .pyenvrc
+  template:
+    src: ".pyenvrc.j2"
+    dest: "{{ pyenv_root }}/.pyenvrc"
+    mode: "0644"

--- a/tasks/shell.yml
+++ b/tasks/shell.yml
@@ -18,9 +18,9 @@
 - name: Check whether .pyenvrc is loaded in .bashrc
   command: grep -EFq 'source $HOME/.pyenv/.pyenvrc' {{ pyenv_bashrc_path }}
   register: check_bashrc
-  ignore_errors: True
-  changed_when: False
-  failed_when: False
+  ignore_errors: true
+  changed_when: false
+  failed_when: false
   when: pyenv_bashrc_st.stat.exists
 
 - name: Load pyenv in .bashrc
@@ -56,9 +56,9 @@
 - name: Check whether .pyenvrc is loaded in .zshrc
   command: grep -Fq 'source $HOME/.pyenv/.pyenvrc' {{ pyenv_zshrc_path }}
   register: check_zshrc
-  ignore_errors: True
-  changed_when: False
-  failed_when: False
+  ignore_errors: true
+  changed_when: false
+  failed_when: false
   when: pyenv_zshrc_st.stat.exists
 
 - name: Load pyenv in .zshrc

--- a/tests/Dockerfile.template
+++ b/tests/Dockerfile.template
@@ -1,11 +1,11 @@
-FROM ubuntu:xenial
+FROM %%FROM%%
 
 RUN apt-get update && apt-get install -y \
     python-minimal \
     python-pip \
  && rm -rf /var/lib/apt/lists/*
 
-ARG ansible_version="<2.9.0"
+ARG ansible_version="%%ANSIBLE_VERSION%%"
 ENV ANSIBLE_VERSION="${ansible_version}"
 RUN pip install ansible${ANSIBLE_VERSION}
 
@@ -18,8 +18,8 @@ RUN apt-get update && apt-get install -y \
     aptitude \
  && rm -rf /var/lib/apt/lists/*
 
-ARG user=test
-ARG repository=ansible-pyenv
+ARG user=%%USER%%
+ARG repository=%%REPOSITORY%%
 
 # Create test user
 RUN useradd -m ${user} -s /bin/bash \

--- a/tests/bionic/Dockerfile
+++ b/tests/bionic/Dockerfile
@@ -5,7 +5,7 @@ RUN apt-get update && apt-get install -y \
     python-pip \
  && rm -rf /var/lib/apt/lists/*
 
-ARG ansible_version="<2.8.0"
+ARG ansible_version="<2.9.0"
 ENV ANSIBLE_VERSION="${ansible_version}"
 RUN pip install ansible${ANSIBLE_VERSION}
 
@@ -14,15 +14,24 @@ RUN apt-get update && apt-get install -y \
     sudo \
  && rm -rf /var/lib/apt/lists/*
 
+RUN apt-get update && apt-get install -y \
+    aptitude \
+ && rm -rf /var/lib/apt/lists/*
+
+ARG user=test
+ARG repository=ansible-pyenv
+
 # Create test user
-RUN useradd -m test -s /bin/bash \
- && echo "test:test" | chpasswd \
- && adduser test sudo \
+RUN useradd -m ${user} -s /bin/bash \
+ && echo "${user}:${user}" | chpasswd \
+ && adduser ${user} sudo \
  && echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
-RUN touch /home/test/.zshrc && chown -R test:test /home/test
+RUN touch /home/${user}/.zshrc \
+ && chown -R ${user}:${user} /home/${user}
 
 # Create directory for code
-RUN mkdir -p /home/test/ansible-pyenv ; chown -R test:test /home/test/ansible-pyenv
-VOLUME ["/home/test/ansible-pyenv"]
+RUN mkdir -p /home/${user}/${repository} ; \
+    chown -R ${user}:${user} /home/${user}/${repository}
+VOLUME ["/home/${user}/${repository}"]
 
 CMD exec /bin/bash -c "trap : TERM INT; sleep infinity & wait"

--- a/tests/buster/Dockerfile
+++ b/tests/buster/Dockerfile
@@ -5,7 +5,7 @@ RUN apt-get update && apt-get install -y \
     python-pip \
  && rm -rf /var/lib/apt/lists/*
 
-ARG ansible_version="<2.8.0"
+ARG ansible_version="<2.9.0"
 ENV ANSIBLE_VERSION="${ansible_version}"
 RUN pip install ansible${ANSIBLE_VERSION}
 
@@ -14,15 +14,24 @@ RUN apt-get update && apt-get install -y \
     sudo \
  && rm -rf /var/lib/apt/lists/*
 
+RUN apt-get update && apt-get install -y \
+    aptitude \
+ && rm -rf /var/lib/apt/lists/*
+
+ARG user=test
+ARG repository=ansible-pyenv
+
 # Create test user
-RUN useradd -m test -s /bin/bash \
- && echo "test:test" | chpasswd \
- && adduser test sudo \
+RUN useradd -m ${user} -s /bin/bash \
+ && echo "${user}:${user}" | chpasswd \
+ && adduser ${user} sudo \
  && echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
-RUN touch /home/test/.zshrc && chown -R test:test /home/test
+RUN touch /home/${user}/.zshrc \
+ && chown -R ${user}:${user} /home/${user}
 
 # Create directory for code
-RUN mkdir -p /home/test/ansible-pyenv ; chown -R test:test /home/test/ansible-pyenv
-VOLUME ["/home/test/ansible-pyenv"]
+RUN mkdir -p /home/${user}/${repository} ; \
+    chown -R ${user}:${user} /home/${user}/${repository}
+VOLUME ["/home/${user}/${repository}"]
 
 CMD exec /bin/bash -c "trap : TERM INT; sleep infinity & wait"

--- a/tests/inventory
+++ b/tests/inventory
@@ -1,2 +1,1 @@
 localhost
-

--- a/tests/run-tests
+++ b/tests/run-tests
@@ -3,7 +3,7 @@
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 PROJECT_ROOT=$(dirname $DIR)
 
-ROLE_NAME=ansible-pyenv
+ROLE_NAME="$(basename $PROJECT_ROOT)"
 TEST_HOME=/home/test
 
 ###
@@ -81,6 +81,14 @@ trap finish EXIT
 
 detect_wsl
 
+cd $DIR
+
+images=( "$@" )
+if [ ${#images[@]} -eq 0 ]; then
+    images=( */Dockerfile )
+    images=( "${images[@]/\/Dockerfile/}" )
+fi
+
 cd $PROJECT_ROOT
 
 if [ "${is_wsl}" == "1" ]; then
@@ -91,7 +99,6 @@ fi
 
 set -e
 
-images=( bionic xenial stretch buster )
 for i in "${images[@]}"; do
     build $i
     start $i

--- a/tests/stretch/Dockerfile
+++ b/tests/stretch/Dockerfile
@@ -5,7 +5,7 @@ RUN apt-get update && apt-get install -y \
     python-pip \
  && rm -rf /var/lib/apt/lists/*
 
-ARG ansible_version="<2.8.0"
+ARG ansible_version="<2.9.0"
 ENV ANSIBLE_VERSION="${ansible_version}"
 RUN pip install ansible${ANSIBLE_VERSION}
 
@@ -14,15 +14,24 @@ RUN apt-get update && apt-get install -y \
     sudo \
  && rm -rf /var/lib/apt/lists/*
 
+RUN apt-get update && apt-get install -y \
+    aptitude \
+ && rm -rf /var/lib/apt/lists/*
+
+ARG user=test
+ARG repository=ansible-pyenv
+
 # Create test user
-RUN useradd -m test -s /bin/bash \
- && echo "test:test" | chpasswd \
- && adduser test sudo \
+RUN useradd -m ${user} -s /bin/bash \
+ && echo "${user}:${user}" | chpasswd \
+ && adduser ${user} sudo \
  && echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
-RUN touch /home/test/.zshrc && chown -R test:test /home/test
+RUN touch /home/${user}/.zshrc \
+ && chown -R ${user}:${user} /home/${user}
 
 # Create directory for code
-RUN mkdir -p /home/test/ansible-pyenv ; chown -R test:test /home/test/ansible-pyenv
-VOLUME ["/home/test/ansible-pyenv"]
+RUN mkdir -p /home/${user}/${repository} ; \
+    chown -R ${user}:${user} /home/${user}/${repository}
+VOLUME ["/home/${user}/${repository}"]
 
 CMD exec /bin/bash -c "trap : TERM INT; sleep infinity & wait"

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -1,4 +1,5 @@
 ---
+
 - hosts: localhost
   remote_user: root
   roles:

--- a/tests/update
+++ b/tests/update
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+set -euo pipefail
+
+cd "$(dirname "$(readlink -f "$BASH_SOURCE")")"
+
+user="test"
+repository="$(basename $(dirname $(pwd)))"
+ansible_version="<2.9.0"
+
+image="ubuntu"
+ubuntu_releases=(xenial bionic)
+for tag in "${ubuntu_releases[@]}"; do
+    dir="${tag}"
+    echo "*** Updating $dir/Dockerfile"
+    sed -r \
+        -e 's!%%FROM%%!'"$image:$tag"'!g' \
+        -e 's!%%USER%%!'"$user"'!g' \
+        -e 's!%%REPOSITORY%%!'"$repository"'!g' \
+        -e 's!%%ANSIBLE_VERSION%%!'"$ansible_version"'!g' \
+        "Dockerfile.template" > "$dir/Dockerfile"
+done
+
+image="debian"
+debian_releases=(stretch buster)
+for tag in "${debian_releases[@]}"; do
+    dir="${tag}"
+    echo "*** Updating $dir/Dockerfile"
+    sed -r \
+        -e 's!%%FROM%%!'"$image:$tag"'!g' \
+        -e 's!%%USER%%!'"$user"'!g' \
+        -e 's!%%REPOSITORY%%!'"$repository"'!g' \
+        -e 's!%%ANSIBLE_VERSION%%!'"$ansible_version"'!g' \
+        "Dockerfile.template" > "$dir/Dockerfile"
+done


### PR DESCRIPTION
Travis pipeline improvements using build stages.

Fix deprecation warnings in Ansible 2.8.

Use strict yamllint configuration.

Install pyenv from Git repository on macOS to fix issue #16.

Use a template for generating Dockerfiles used for local testing.