### PR TITLE
fix: install fails on macOS Mojave

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -110,10 +110,6 @@ stages:
   - test
 
 jobs:
-  allow_failures:
-    - osx_image: xcode10.2
-      env: FROM_PACKAGE_MANAGER='yes'
-
   include:
 
     # Run validation stage in Linux with latest Ansible only
@@ -143,6 +139,7 @@ jobs:
       dist: bionic
       env: ANSIBLE_VERSION='<2.9.0'
 
+    # https://docs.travis-ci.com/user/reference/osx/#xcode-101
     - stage: test
       name: "macOS 10.13 (High Sierra) with Xcode 10.1 with Homebrew"
       os: osx
@@ -154,6 +151,7 @@ jobs:
       osx_image: xcode10.1
       env: FROM_PACKAGE_MANAGER='no'
 
+    # https://docs.travis-ci.com/user/reference/osx/#xcode-102
     - stage: test
       name: "macOS 10.14 (Mojave) with Xcode 10.2.1 with Homebrew"
       os: osx
@@ -163,6 +161,18 @@ jobs:
       name: "macOS 10.14 (Mojave) with Xcode 10.2.1 from Git"
       os: osx
       osx_image: xcode10.2
+      env: FROM_PACKAGE_MANAGER='no'
+
+    # https://docs.travis-ci.com/user/reference/osx/#xcode-110
+    - stage: test
+      name: "macOS 10.14 (Mojave) with Xcode 11.0 with Homebrew"
+      os: osx
+      osx_image: xcode11
+      env: FROM_PACKAGE_MANAGER='yes'
+    - stage: test
+      name: "macOS 10.14 (Mojave) with Xcode 11.0 from Git"
+      os: osx
+      osx_image: xcode11
       env: FROM_PACKAGE_MANAGER='no'
 
 notifications:

--- a/tasks/Darwin.yml
+++ b/tasks/Darwin.yml
@@ -5,12 +5,9 @@
     macos_version: "{{ ansible_distribution_version |
                     regex_search('^([0-9]+\\.[0-9]+)') }}"
 
-- name: Install macOS SDK headers for macOS 10.14 (Mojave)
-  become: true
-  command: "installer -pkg {{ mojave_sdk_headers }} -target /"
+- name: macOS Mojave setup
+  include_tasks: "Mojave.yml"
   when: macos_version == "10.14"
-  args:
-    creates: /usr/include
 
 - name: Install pyenv build requirements with Homebrew
   homebrew:

--- a/tasks/Mojave.yml
+++ b/tasks/Mojave.yml
@@ -1,0 +1,65 @@
+---
+
+- name: Include Mojave variables
+  include_vars: "os/Mojave.yml"
+
+- name: Check if headers package exists
+  stat:
+    path: "{{ mojave_sdk_headers }}"
+  register: mojave_sdk_headers_st
+
+- name: Install macOS SDK headers for macOS 10.14
+  become: true
+  command: "installer -pkg {{ mojave_sdk_headers }} -target /"
+  args:
+    creates: /usr/include
+  when: mojave_sdk_headers_st.stat.exists
+
+- name: Use existing MACOSX_DEPLOYMENT_TARGET environment variable
+  set_fact:
+    macos_target: "{{ lookup('env', 'MACOSX_DEPLOYMENT_TARGET' )
+                    | ternary (lookup('env', 'MACOSX_DEPLOYMENT_TARGET' ), macos_version) }}"
+
+- name: Set MACOSX_DEPLOYMENT_TARGET environment variable
+  set_fact:
+    pyenv_install_environment: "{{ pyenv_install_environment
+                                 | combine({ 'MACOSX_DEPLOYMENT_TARGET': macos_target }) }}"
+
+- name: Use existing SDKROOT environment variable
+  set_fact:
+    sdkroot: "{{ lookup('env', 'SDKROOT' )
+               | ternary (lookup('env', 'SDKROOT' ), omit) }}"
+
+- name: Find macOS SDK headers and set SDKROOT
+  when: sdkroot is undefined
+  block:
+
+    - name: Look for macOS SDK in Xcode
+      stat:
+        path: "/Applications/{{ item.app }}/{{ xcode_sdk_path }}/{{ item.sdk }}"
+      with_items: "{{ xcode_sdk_lookup }}"
+      register: xcode_sdk_st
+
+    - name: Set path to macOS SDK in Xcode
+      set_fact:
+        sdkroot: "{{ item.stat.path }}"
+      with_items: "{{ xcode_sdk_st.results }}"
+      when:
+        - item.stat.exists
+
+    - name: Look for macOS SDK in Command Line Tools
+      stat:
+        path: "/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk"
+      register: clt_sdk_st
+      when: sdkroot is undefined
+
+    - name: Set path to macOS SDK in Command Line Tools
+      set_fact:
+        sdkroot: "{{ clt_sdk_st.stat.path }}"
+      when: sdkroot is undefined and clt_sdk_st.stat.exists
+
+- name: Set SDKROOT environment variable
+  set_fact:
+    pyenv_install_environment: "{{ pyenv_install_environment
+                                 | combine({ 'SDKROOT': sdkroot }) }}"
+  when: sdkroot is defined

--- a/tasks/python_versions.yml
+++ b/tasks/python_versions.yml
@@ -8,6 +8,7 @@
     executable: "{{ pyenv_install_shell | default(omit) }}"
     creates: "{{ pyenv_root }}/versions/{{ item }}/bin/python"
   with_items: "{{ pyenv_python_versions }}"
+  environment: "{{ pyenv_install_environment }}"
 
 - name: Get current global version
   shell: >-

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,0 +1,3 @@
+---
+
+pyenv_install_environment: {}

--- a/vars/os/Darwin.yml
+++ b/vars/os/Darwin.yml
@@ -4,5 +4,3 @@ pyenv_build_requirements:
   - openssl
   - readline
   - xz
-
-mojave_sdk_headers: '/Library/Developer/CommandLineTools/Packages/macOS_SDK_headers_for_macOS_10.14.pkg'

--- a/vars/os/Mojave.yml
+++ b/vars/os/Mojave.yml
@@ -1,0 +1,13 @@
+---
+
+xcode_sdk_path: Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs
+xcode_sdk_lookup:
+  - app: "Xcode.app"
+    sdk: "MacOSX10.14.sdk"
+  - app: "Xcode-10.2.1.app"
+    sdk: "MacOSX10.14.sdk"
+  - app: "Xcode.app"
+    sdk: "MacOSX10.15.sdk"
+  - app: "Xcode-11.app"
+    sdk: "MacOSX10.15.sdk"
+mojave_sdk_headers: /Library/Developer/CommandLineTools/Packages/macOS_SDK_headers_for_macOS_10.14.pkg


### PR DESCRIPTION
Set `SDKROOT` and `MACOSX_DEPLOYMENT_TARGET` environment variables when installing new versions on macOS 10.14.

Add Travis CI test image for Xcode 11.0.