### PR TITLE
Default to Homebrew on macOS and detect existing install

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -75,11 +75,23 @@ script:
   - >
     if [[ "$FROM_PACKAGE_MANAGER" == "yes" ]]; then
       ansible-playbook tests/test.yml -i tests/inventory --connection=local \
-        -e "{'pyenv_install_from_package_manager':'True'}" \
+        -e "{'pyenv_install_from_package_manager':true}" \
         || travis_terminate 1
     else
       ansible-playbook tests/test.yml -i tests/inventory --connection=local \
-        -e "{'pyenv_install_from_package_manager':'False'}" \
+        -e "{'pyenv_install_from_package_manager':false}" \
+        || travis_terminate 1
+    fi
+
+  # Debug idempotence test
+  - >
+    if [[ "$FROM_PACKAGE_MANAGER" == "yes" ]]; then
+      ansible-playbook tests/test.yml -i tests/inventory --connection=local \
+        -e "{'pyenv_install_from_package_manager':true}" \
+        || travis_terminate 1
+    else
+      ansible-playbook tests/test.yml -i tests/inventory --connection=local \
+        -e "{'pyenv_install_from_package_manager':false}" \
         || travis_terminate 1
     fi
 
@@ -87,13 +99,13 @@ script:
   - >
     if [[ "$FROM_PACKAGE_MANAGER" == "yes" ]]; then
       ansible-playbook tests/test.yml -i tests/inventory --connection=local \
-      -e "{'pyenv_install_from_package_manager':'True'}" \
+      -e "{'pyenv_install_from_package_manager':true}" \
         | grep -q 'changed=0.*failed=0' \
         && (echo 'Idempotence test: pass' && exit 0) \
         || (echo 'Idempotence test: fail' && exit 1)
     else
       ansible-playbook tests/test.yml -i tests/inventory --connection=local \
-      -e "{'pyenv_install_from_package_manager':'False'}" \
+      -e "{'pyenv_install_from_package_manager':failed}" \
         | grep -q 'changed=0.*failed=0' \
         && (echo 'Idempotence test: pass' && exit 0) \
         || (echo 'Idempotence test: fail' && exit 1)

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -5,7 +5,7 @@
 pyenv_home: "{{ ansible_env.HOME }}"
 pyenv_root: "{{ ansible_env.HOME }}/.pyenv"
 
-# Configure shell
+# Initialize .bashrc and .zshrc shell scripts
 pyenv_init_shell: true
 
 # Versions to install
@@ -30,4 +30,7 @@ pyenv_virtualenvwrapper: false
 pyenv_virtualenvwrapper_home: "{{ ansible_env.HOME }}/.virtualenvs"
 
 # Install using package manager where available
-pyenv_install_from_package_manager: false
+pyenv_install_from_package_manager: true
+
+# Detect existing install
+pyenv_detect_existing_install: true

--- a/tasks/Darwin.yml
+++ b/tasks/Darwin.yml
@@ -13,9 +13,17 @@
   homebrew:
     name: "{{ pyenv_build_requirements }}"
 
+- name: Detect existing pyenv install
+  include_tasks: detect_existing_install.yml
+  when: pyenv_detect_existing_install|bool
+
 - name: Install with Homebrew
   include_tasks: install_with_homebrew.yml
   when: pyenv_install_from_package_manager|bool
+
+- name: Uninstall Homebrew packages
+  include_tasks: remove_homebrew.yml
+  when: not pyenv_install_from_package_manager|bool
 
 - name: Install with Git
   include_tasks: install_with_git.yml

--- a/tasks/detect_existing_install.yml
+++ b/tasks/detect_existing_install.yml
@@ -1,0 +1,25 @@
+---
+
+- name: Check if ~/.pyenv directory already exists
+  stat:
+    path: "{{ pyenv_root }}"
+  register: pyenv_root_st
+
+- name: Existing ~/.pyenv install found
+  when: pyenv_root_st.stat.exists
+  block:
+
+    - name: Check if ~/.pyenv directory is a Git repository
+      stat:
+        path: "{{ pyenv_root }}/.git"
+      register: pyenv_root_git_st
+
+    - name: Install from Homebrew
+      set_fact:
+        pyenv_install_from_package_manager: true
+      when: not pyenv_root_git_st.stat.exists
+
+    - name: Install from Git
+      set_fact:
+        pyenv_install_from_package_manager: false
+      when: pyenv_root_git_st.stat.exists

--- a/tasks/remove_homebrew.yml
+++ b/tasks/remove_homebrew.yml
@@ -1,0 +1,16 @@
+---
+
+- name: Remove pyenv installed with Homebrew
+  homebrew:
+    name: pyenv
+    state: absent
+
+- name: Remove pyenv-virtualenv installed with Homebrew
+  homebrew:
+    name: pyenv-virtualenv
+    state: absent
+
+- name: Remove pyenv-virtualenvwrapper installed with Homebrew
+  homebrew:
+    name: pyenv-virtualenvwrapper
+    state: absent


### PR DESCRIPTION
The Git install was enabled to address issues with newer pyenv versions on macOS Mojave, but as using old pyenv version prevents from installing the latest Python versions, holding this back wasn't a good approach.
    
The installation issues with macOS Mojave been been fixed, so reverting this back to the previous setting.
    
The role doesn't know how to migrate from existing Homebrew installs to Git-based installations, so it will try to detect any existing installation and keep using the previous method.

Remove Homebrew packages if using Git install.