### PR TITLE
fix: fully qualify pyenv calls to work on non-interactive shells

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -1,2 +1,5 @@
 exclude_paths:
 - .travis.yml
+
+warn_list:
+    - '305'

--- a/tasks/python_versions.yml
+++ b/tasks/python_versions.yml
@@ -25,8 +25,7 @@
 
 - name: Install Python interpreters
   shell: >-
-    . {{ pyenv_root }}/.pyenvrc &&
-    pyenv install {{ item }}
+    {{ pyenv_root }}/bin/pyenv install {{ item }}
   args:
     executable: "{{ pyenv_install_shell | default(omit) }}"
     creates: "{{ pyenv_root }}/versions/{{ item }}/bin/python"
@@ -60,8 +59,7 @@
 
 - name: Get current global version
   shell: >-
-    . {{ pyenv_root }}/.pyenvrc &&
-    pyenv global
+    {{ pyenv_root }}/bin/pyenv global
   args:
     executable: "{{ pyenv_install_shell | default(omit) }}"
   register: pyenv_global_version
@@ -75,8 +73,7 @@
 - name: Check if 'system' version is available
   shell: >-
     set -o pipefail &&
-    . {{ pyenv_root }}/.pyenvrc &&
-    pyenv versions | grep -q system
+    {{ pyenv_root }}/bin/pyenv versions | grep -q system
   args:
     executable: "{{ pyenv_install_shell | default(omit) }}"
   register: pyenv_versions_grep_system
@@ -91,9 +88,8 @@
 
 - name: Set pyenv global version to '{{ pyenv_global }}'
   shell: >-
-    . {{ pyenv_root }}/.pyenvrc &&
-    pyenv global {{ pyenv_global }} &&
-    pyenv rehash
+    {{ pyenv_root }}/bin/pyenv global &&
+    {{ pyenv_root }}/bin/pyenv rehash
   args:
     executable: "{{ pyenv_install_shell | default(omit) }}"
   when: "pyenv_global is defined and pyenv_global_active != pyenv_global"


### PR DESCRIPTION
Hey markosamuli
Thanks for this role.
I recently tried using it over ssh/non-interactive login shells and several of the `shell` module calls to `pyenv` failed. This hasn't been an issue when using `ansible_connection=localhost` as I typically do with my dev machines. Recently I've been setting up a couple of dev machines, which is nicer to do simultaneously over ssh.
Turns out this is because `eval $(pyenv init -)` is placed in `~/.zshrc`which doesn't run for non-interactive shells. Moving  `eval $(pyenv init -)` to `~/.zshenv` works but slows down shell startup in other ways.
Given we know `pyenv_root` I figure we can call `pyenv` directly. From the local testing I've done, this appears to be a safe change that will continue to work on `localhost` connections as well as `ssh` and not require any environment hacks for SSH use.
Only weird hiccup - I got an ansible-lint failure for using the `shell` module. It was already in use, so unsure why that's an issue. I added the appropriate ignore rule in `.ansible-lint` but feel free to tweak if that is inappropriate.

Great role again dude :+1: 