### PR TITLE
feat: remote install without interactive shell

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,11 @@ Unreleased changes.
 
 ### Changed
 
+Use `pyenv` binary directly instead of loading the `.pyenvrc` file as suggested
+by [@KentBrockman](https://github.com/KentBrockman) in [PR #39][pr39]. This will
+allow installation of the role using remote SSH connections without the need
+for interactive shell.
+
 Remove links to Travis CI as the [tests are no longer working][travis] for
 open source projects.
 
@@ -43,6 +48,7 @@ Update versions:
 
 [pip-tools]: https://github.com/jazzband/pip-tools
 [travis]: https://github.com/markosamuli/ansible-pyenv/issues/45
+[pr39]: https://github.com/markosamuli/ansible-pyenv/pull/39
 
 ## [4.0.2] - 2020-09-11
 

--- a/tasks/global_version.yml
+++ b/tasks/global_version.yml
@@ -1,0 +1,36 @@
+---
+- name: Get current global version # noqa 305
+  shell: >-
+    {{ pyenv_bin_path }} global
+  args:
+    executable: "{{ pyenv_install_shell | default(omit) }}"
+  register: pyenv_global_version
+  changed_when: false
+
+- name: Set pyenv_global_active fact
+  set_fact:
+    pyenv_global_active: "{{ pyenv_global_version.stdout_lines |
+      join(' ') | trim() }}"
+
+- name: Check if 'system' version is available # noqa 305
+  shell: >-
+    {{ pyenv_bin_path }} versions
+  args:
+    executable: "{{ pyenv_install_shell | default(omit) }}"
+  register: pyenv_versions
+  changed_when: false
+  failed_when: false
+  when: "'system' in pyenv_global"
+
+- name: Remove 'system' from pyenv_global
+  set_fact:
+    pyenv_global: "{{ pyenv_global | replace('system', '') | trim() }}"
+  when: "'system' in pyenv_global and 'system' not in pyenv_versions.stdout"
+
+- name: Set pyenv global version to '{{ pyenv_global }}'
+  shell: >-
+    {{ pyenv_bin_path }} global {{ pyenv_global }} &&
+    {{ pyenv_bin_path }} rehash
+  args:
+    executable: "{{ pyenv_install_shell | default(omit) }}"
+  when: "pyenv_global is defined and pyenv_global_active != pyenv_global"

--- a/tasks/install_with_git.yml
+++ b/tasks/install_with_git.yml
@@ -17,3 +17,8 @@
     dest: "{{ pyenv_root }}/plugins/pyenv-virtualenvwrapper"
     version: "{{ pyenv_virtualenvwrapper_version }}"
   when: pyenv_virtualenvwrapper|bool
+
+- name: Set path to pyenv binary
+  set_fact:
+    pyenv_bin_path: "{{ pyenv_root }}/bin/pyenv"
+  when: pyenv_bin_path is undefined

--- a/tasks/install_with_homebrew.yml
+++ b/tasks/install_with_homebrew.yml
@@ -4,9 +4,7 @@
     pyenv_required_version: "{{ pyenv_version | regex_replace('^v(.*)$', '\\1') }}"
 
 - name: Homebrew path set
-  when:
-    - pyenv_brew_path is defined
-    - pyenv_brew_path != '' # noqa 602
+  when: pyenv_brew_path is defined and pyenv_brew_path != '' # noqa 602
   block:
     - name: Check brew binary exists
       stat:
@@ -18,6 +16,10 @@
         msg: "brew not found in {{ pyenv_brew_path }}"
       when: not brew_st.stat.exists | bool
 
+    - name: Set path to brew binary
+      set_fact:
+        pyenv_brew_bin_path: "{{ pyenv_brew_path }}/brew"
+
 - name: Install pyenv with Homebrew
   homebrew:
     name: pyenv
@@ -25,8 +27,22 @@
     state: present
     update_homebrew: false
 
+- name: Set path to pyenv binary
+  when: pyenv_bin_path is undefined
+  block:
+    - name: Get pyenv installation prefix
+      shell: "{{ pyenv_brew_bin_path | default('brew') }} --prefix pyenv" # noqa 305
+      args:
+        executable: "{{ pyenv_install_shell | default(omit) }}"
+      register: pyenv_brew_prefix
+      changed_when: false
+
+    - name: Set path to pyenv binary
+      set_fact:
+        pyenv_bin_path: "{{ pyenv_brew_prefix.stdout }}/bin/pyenv"
+
 - name: Get brew info on pyenv package
-  shell: "brew info pyenv --json" # noqa 305
+  shell: "{{ pyenv_brew_bin_path | default('brew') }} info pyenv --json" # noqa 305
   args:
     executable: "{{ pyenv_install_shell | default(omit) }}"
   register: brew_info

--- a/tasks/python_versions.yml
+++ b/tasks/python_versions.yml
@@ -1,99 +1,26 @@
 ---
-- name: Remove readline from Homebrew on Linux
-  homebrew:
-    name: readline
-    state: absent
-    install_options: "ignore-dependencies"
-    path: "{{ pyenv_brew_path | default(omit) }}"
-  register: pyenv_brew_readline_uninstall
-  changed_when: false
-  when: >-
-    ansible_system == 'Linux'
-    and pyenv_homebrew_on_linux | bool
+- name: Check environment variables
+  assert:
+    that:
+      - "pyenv_bin_path is defined"
+    msg: "pyenv binary path not defined"
 
-- name: Unlink Homebrew OpenSSL on Linux
-  homebrew:
-    name: openssl
-    state: unlinked
-    path: "{{ pyenv_brew_path | default(omit) }}"
-  register: pyenv_brew_openssl_unlink
-  changed_when: false
-  when: >-
-    ansible_system == 'Linux'
-    and pyenv_homebrew_on_linux | bool
-    and pyenv_homebrew_openssl_fix | bool
-
-- name: Install Python interpreters
-  shell: >-
-    . {{ pyenv_root }}/.pyenvrc &&
-    pyenv install {{ item }}
-  args:
-    executable: "{{ pyenv_install_shell | default(omit) }}"
-    creates: "{{ pyenv_root }}/versions/{{ item }}/bin/python"
-  with_items: "{{ pyenv_python_versions }}"
-  environment: "{{ pyenv_install_environment }}"
-
-- name: Install readline with Homebrew on Linux # noqa 503
-  homebrew:
-    name: readline
-    state: present
-    path: "{{ pyenv_brew_path | default(omit) }}"
-  changed_when: false
-  when: >-
-    ansible_system == 'Linux'
-    and pyenv_homebrew_on_linux | bool
-    and pyenv_brew_readline_uninstall is defined
-    and pyenv_brew_readline_uninstall.changed
-
-- name: Link Homebrew OpenSSL on Linux # noqa 503
-  homebrew:
-    name: openssl
-    state: linked
-    path: "{{ pyenv_brew_path | default(omit) }}"
-  changed_when: false
-  when: >-
-    ansible_system == 'Linux'
-    and pyenv_homebrew_on_linux | bool
-    and pyenv_homebrew_openssl_fix | bool
-    and pyenv_brew_openssl_unlink is defined
-    and pyenv_brew_openssl_unlink.changed
-
-- name: Get current global version
-  shell: >-
-    . {{ pyenv_root }}/.pyenvrc &&
-    pyenv global
-  args:
-    executable: "{{ pyenv_install_shell | default(omit) }}"
-  register: pyenv_global_version
+- name: Check that pyenv binary exists
+  stat:
+    path: "{{ pyenv_bin_path }}"
+  register: pyenv_bin_st
+  failed_when: not pyenv_bin_st.stat.exists
   changed_when: false
 
-- name: Set pyenv_global_active fact
-  set_fact:
-    pyenv_global_active: "{{ pyenv_global_version.stdout_lines |
-      join(' ') | trim() }}"
+- name: Install python versions with Git install
+  include_tasks: python_versions_with_git.yml
+  when: (ansible_system == 'Linux' and not pyenv_homebrew_on_linux) or
+    (ansible_os_family == 'Darwin' and not pyenv_install_from_package_manager)
 
-- name: Check if 'system' version is available
-  shell: >-
-    set -o pipefail &&
-    . {{ pyenv_root }}/.pyenvrc &&
-    pyenv versions | grep -q system
-  args:
-    executable: "{{ pyenv_install_shell | default(omit) }}"
-  register: pyenv_versions_grep_system
-  changed_when: false
-  failed_when: false
-  when: "'system' in pyenv_global"
+- name: Install python versions with Homebrew install
+  include_tasks: python_versions_with_homebrew.yml
+  when: (ansible_system == 'Linux' and pyenv_homebrew_on_linux) or
+    (ansible_os_family == 'Darwin' and pyenv_install_from_package_manager)
 
-- name: Remove 'system' from pyenv_global
-  set_fact:
-    pyenv_global: "{{ pyenv_global | replace('system', '') | trim() }}"
-  when: "'system' in pyenv_global and pyenv_versions_grep_system.rc != 0"
-
-- name: Set pyenv global version to '{{ pyenv_global }}'
-  shell: >-
-    . {{ pyenv_root }}/.pyenvrc &&
-    pyenv global {{ pyenv_global }} &&
-    pyenv rehash
-  args:
-    executable: "{{ pyenv_install_shell | default(omit) }}"
-  when: "pyenv_global is defined and pyenv_global_active != pyenv_global"
+- name: Set global version
+  include_tasks: global_version.yml

--- a/tasks/python_versions_with_git.yml
+++ b/tasks/python_versions_with_git.yml
@@ -1,0 +1,9 @@
+---
+- name: Install Python interpreters # noqa 305
+  shell: >-
+    {{ pyenv_bin_path }} install {{ item }}
+  args:
+    executable: "{{ pyenv_install_shell | default(omit) }}"
+    creates: "{{ pyenv_root }}/versions/{{ item }}/bin/python"
+  with_items: "{{ pyenv_python_versions }}"
+  environment: "{{ pyenv_install_environment }}"

--- a/tasks/python_versions_with_homebrew.yml
+++ b/tasks/python_versions_with_homebrew.yml
@@ -1,0 +1,58 @@
+---
+- name: Remove readline from Homebrew on Linux
+  homebrew:
+    name: readline
+    state: absent
+    install_options: "ignore-dependencies"
+    path: "{{ pyenv_brew_path | default(omit) }}"
+  register: pyenv_brew_readline_uninstall
+  changed_when: false
+  when: >-
+    ansible_system == 'Linux'
+    and pyenv_homebrew_on_linux | bool
+
+- name: Unlink Homebrew OpenSSL on Linux
+  homebrew:
+    name: openssl
+    state: unlinked
+    path: "{{ pyenv_brew_path | default(omit) }}"
+  register: pyenv_brew_openssl_unlink
+  changed_when: false
+  when: >-
+    ansible_system == 'Linux'
+    and pyenv_homebrew_on_linux | bool
+    and pyenv_homebrew_openssl_fix | bool
+
+- name: Install Python interpreters # noqa 305
+  shell: >-
+    {{ pyenv_bin_path }} install {{ item }}
+  args:
+    executable: "{{ pyenv_install_shell | default(omit) }}"
+    creates: "{{ pyenv_root }}/versions/{{ item }}/bin/python"
+  with_items: "{{ pyenv_python_versions }}"
+  environment: "{{ pyenv_install_environment }}"
+
+- name: Install readline with Homebrew on Linux # noqa 503
+  homebrew:
+    name: readline
+    state: present
+    path: "{{ pyenv_brew_path | default(omit) }}"
+  changed_when: false
+  when: >-
+    ansible_system == 'Linux'
+    and pyenv_homebrew_on_linux | bool
+    and pyenv_brew_readline_uninstall is defined
+    and pyenv_brew_readline_uninstall.changed
+
+- name: Link Homebrew OpenSSL on Linux # noqa 503
+  homebrew:
+    name: openssl
+    state: linked
+    path: "{{ pyenv_brew_path | default(omit) }}"
+  changed_when: false
+  when: >-
+    ansible_system == 'Linux'
+    and pyenv_homebrew_on_linux | bool
+    and pyenv_homebrew_openssl_fix | bool
+    and pyenv_brew_openssl_unlink is defined
+    and pyenv_brew_openssl_unlink.changed

--- a/vars/os/Darwin.yml
+++ b/vars/os/Darwin.yml
@@ -5,3 +5,5 @@ pyenv_build_requirements_with_homebrew:
   - readline
   - xz
   - gcc
+
+pyenv_brew_path: /usr/local/bin


### PR DESCRIPTION
Includes fix suggested by @KentBrockman in #39 with the changes 
required to avoid breaking existing Homebrew installations that
don't install the pyenv binary under ~/.pyenv directory.