### PR TITLE
feat: install interpreters only when necessary

### DIFF
--- a/tasks/versions/python_versions_with_git.yml
+++ b/tasks/versions/python_versions_with_git.yml
@@ -1,4 +1,12 @@
 ---
+- name: Check if interpreters installed
+  ansible.builtin.shell: >-
+    {{ pyenv_bin_path }} versions
+  args:
+    executable: "{{ pyenv_install_shell | default(omit) }}"
+  environment: "{{ pyenv_install_environment }}"
+  register: pyenv_installed_versions
+
 - name: Install Python interpreters # noqa 305
   ansible.builtin.shell: >-
     {{ pyenv_bin_path }} install {{ item }}
@@ -7,3 +15,4 @@
     creates: "{{ pyenv_root }}/versions/{{ item }}/bin/python"
   with_items: "{{ pyenv_python_versions }}"
   environment: "{{ pyenv_install_environment }}"
+  when: item not in pyenv_installed_versions.stdout


### PR DESCRIPTION
Add a check if the proposed version is already installed prior to installing a given python interpreter. Each item in `pyenv_python_versions` will be checked if it's contained in the output of  `pyenv versions`. If the item was in the output, the execution of the install command will be skipped. Versions not already installed will still be installed during the looping.

Fixes #57