### PR TITLE
specify root user when installing deps

### DIFF
--- a/tasks/install/Linux.yml
+++ b/tasks/install/Linux.yml
@@ -1,6 +1,7 @@
 ---
 - name: Install pyenv build requirements
   become: true
+  become_user: root
   ansible.builtin.package:
     name: "{{ pyenv_build_requirements }}"
     state: present


### PR DESCRIPTION


This PR fixes an issue I ran into when trying to use the role while becoming a non-user

My playbook looked like this
```yml
- name: install pyenv for a specific user
  hosts: my_host
  become: yes
  become_user: my_non_root_user
  roles: [markosamuli.pyenv]
```

When attempting this, the role fails when trying to update dependencies for pyenv on Linux. The reason for that is the role tries to `become` to use `package` which is valid as Ansible defaults `become_user` is `root` but in the case of a user-specific installation it does not work. 
A simple fix is to specify the root user in `Install pyenv build requirements`.